### PR TITLE
script fixed to download srl-conll1.1 data as well

### DIFF
--- a/scripts/fetch_and_make_conll05_data.sh
+++ b/scripts/fetch_and_make_conll05_data.sh
@@ -6,6 +6,13 @@ if [ ! -d $SRLPATH ]; then
   mkdir -p $SRLPATH
 fi
 
+# Download the srl-conll-1.1 data
+conll05_scripts_url="http://www.lsi.upc.edu/~srlconll/srlconll-1.1.tgz"
+pushd $SRLPATH
+wget $conll05_scripts_url
+tar xzvf srlconll-1.1.tgz
+popd
+
 export PERL5LIB="$SRLPATH/srlconll-1.1/lib:$PERL5LIB"
 export PATH="$SRLPATH/srlconll-1.1/bin:$PATH"
 


### PR DESCRIPTION
Needed for PERL5LIB and correct PATH variables, used later in the script.  